### PR TITLE
Added context support for both methods.

### DIFF
--- a/limit.js
+++ b/limit.js
@@ -1,18 +1,19 @@
 /**
  * debounce
  * @param {integer} milliseconds This param indicates the number of milliseconds
- *     to wait after the last call before calling the original function .
+ *     to wait after the last call before calling the original function.
+ * @param {object} What "this" refers to in the returned function.
  * @return {function} This returns a function that when called will wait the
  *     indicated number of milliseconds after the last call before
  *     calling the original function.
  */
-Function.prototype.debounce = function (milliseconds) {
+Function.prototype.debounce = function (milliseconds, context) {
     var baseFunction = this,
         timer = null,
         wait = milliseconds;
 
     return function () {
-        var self = this,
+        var self = context || this,
             args = arguments;
 
         function complete() {

--- a/limit.js
+++ b/limit.js
@@ -32,17 +32,18 @@ Function.prototype.debounce = function (milliseconds) {
 * throttle
 * @param {integer} milliseconds This param indicates the number of milliseconds
 *     to wait between calls before calling the original function.
+* @param {object} What "this" refers to in the returned function.
 * @return {function} This returns a function that when called will wait the
 *     indicated number of milliseconds between calls before
 *     calling the original function.
 */
-Function.prototype.throttle = function (milliseconds) {
+Function.prototype.throttle = function (milliseconds, context) {
     var baseFunction = this,
         lastEventTimestamp = null,
         limit = milliseconds;
 
     return function () {
-        var self = this,
+        var self = context || this,
             args = arguments,
             now = Date.now();
 


### PR DESCRIPTION
I've just discovered these functions and think they're great, with one exception: I wanted a way to bind without having to call `bind()` on the function first.